### PR TITLE
added setCameraPosition to JS and iOS

### DIFF
--- a/scripts/OpenTok.coffee
+++ b/scripts/OpenTok.coffee
@@ -155,6 +155,10 @@ class TBPublisher
   publishVideo: (state) ->
     @publishMedia( "publishVideo", state )
     return @
+  setCameraPosition: (cameraPosition) ->
+    pdebug("setting camera position", cameraPosition: cameraPosition)
+    Cordova.exec(TBSuccess, TBError, OTPlugin, "setCameraPosition", [cameraPosition])
+    return @
   setStyle: (style, value ) ->
     return @
 

--- a/src/ios/OpenTokPlugin.h
+++ b/src/ios/OpenTokPlugin.h
@@ -26,6 +26,7 @@
 // Publisher
 - (void)publishAudio:(CDVInvokedUrlCommand*)command;
 - (void)publishVideo:(CDVInvokedUrlCommand*)command;
+- (void)setCameraPosition:(CDVInvokedUrlCommand*)command;
 - (void)destroy:(CDVInvokedUrlCommand*)command;
 
 // Session

--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -152,6 +152,16 @@
     }
     [_publisher setPublishVideo:pubVideo];
 }
+- (void)setCameraPosition:(CDVInvokedUrlCommand*)command{
+    NSString* publishCameraPosition = [command.arguments objectAtIndex:0];
+    NSLog(@"iOS Altering Video camera position, %@", publishCameraPosition);
+    
+    if ([publishCameraPosition isEqualToString:@"back"]) {
+        [_publisher setCameraPosition:AVCaptureDevicePositionBack];
+    } else if ([publishCameraPosition isEqualToString:@"front"]) {
+        [_publisher setCameraPosition:AVCaptureDevicePositionFront];
+    }
+}
 - (void)destroy:(CDVInvokedUrlCommand*)command{
 }
 

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -206,6 +206,14 @@
       return this;
     };
 
+    TBPublisher.prototype.setCameraPosition = function(cameraPosition) {
+      pdebug("setting camera position", {
+        cameraPosition: cameraPosition
+      });
+      Cordova.exec(TBSuccess, TBError, OTPlugin, "setCameraPosition", [cameraPosition]);
+      return this;
+    };
+
     TBPublisher.prototype.setStyle = function(style, value) {
       return this;
     };


### PR DESCRIPTION
This allows `publisher.setCameraPosition('front')` or `publisher.setCameraPosition('back')` to work.

Sorry, I'm not knowledgeable about how to manipulate the Android side yet.
