### PR TITLE
Update views fix for android

### DIFF
--- a/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
+++ b/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
@@ -385,7 +385,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin implements
         RunnableSubscriber runsub = new RunnableSubscriber( args, stream ); 
         subscriberCollection.put(stream.getStreamId(), runsub);
       }else if( action.equals( "updateView" )){
-        if( args.getString(0).equals("TBPublisher") && myPublisher != null ){
+        if( args.getString(0).equals("TBPublisher") && myPublisher != null && sessionConnected ){
           Log.i( TAG, "updating view for publisher" );
           myPublisher.setPropertyFromArray(args);
           cordova.getActivity().runOnUiThread(myPublisher);


### PR DESCRIPTION
When `OT.updateViews()` is called before the session is connected, the video does not work on android (on iOS it works fine).

This pull request fixes this issue by checking whether the session is connected, and only then will it update the view for publisher.

Notes:

Logcat output when updating view before session is connected:

```
** Log of when it does not work **
--------- beginning of /dev/log/system
--------- beginning of /dev/log/main
D/OTPlugin( 1792): Initialize Plugin
D/OTPlugin( 1792): Found CordovaView ****** org.apache.cordova.CordovaWebView{4212a1b0 IFEDH.C. .F....I. 0,0-0,0 #64}
I/OTPlugin( 1792): updateView
I/OTPlugin( 1792): initPublisher
I/OTPlugin( 1792): addEvent
I/OTPlugin( 1792): adding new event - publisherEvents
I/OTPlugin( 1792): initSession
I/OTPlugin( 1792): created new session with data: ["{OMITTED}","{OMITTED}"]
I/OTPlugin( 1792): addEvent
I/OTPlugin( 1792): adding new event - sessionEvents
I/OTPlugin( 1792): connect
I/OTPlugin( 1792): connect command called
I/OTPlugin( 1792): updateView
I/OTPlugin( 1792): updating view for publisher
I/OTPlugin( 1792): view running on UIVIEW!!!
I/OTPlugin( 1792): error when trying to retrieve publish audio/video property
I/OTPlugin( 1792): updating view in ui runnable["TBPublisher",0,0,264,198,0]
I/OTPlugin( 1792): updating view in ui runnable com.opentok.android.DefaultVideoRenderer$MyRenderView{4229d2b0 V.E..... ......I. 0,0-0,0}
I/OTPlugin( 1792): session connected, triggering sessionConnected Event. My Cid is: {OMITTED}
I/OTPlugin( 1792): publish
I/OTPlugin( 1792): publisher is publishing
I/OTPlugin( 1792): view running on UIVIEW!!!
I/OTPlugin( 1792): updating view in ui runnable["TBPublisher",0,0,264,198,0]
I/OTPlugin( 1792): updating view in ui runnable com.opentok.android.DefaultVideoRenderer$MyRenderView{4229d2b0 V.E..... ........ 0,0-264,198}
```

When calling updateViews after the session is connected:

```
** Log of when it does work **
D/OTPlugin(12227): Initialize Plugin
D/OTPlugin(12227): Found CordovaView ****** org.apache.cordova.CordovaWebView{4212c2f0 IFEDH.C. .F....I. 0,0-0,0 #64}
I/OTPlugin(12227): updateView
I/OTPlugin(12227): initPublisher
I/OTPlugin(12227): addEvent
I/OTPlugin(12227): adding new event - publisherEvents
I/OTPlugin(12227): initSession
I/OTPlugin(12227): created new session with data: ["{OMITTED}","{OMITTED}"]
I/OTPlugin(12227): addEvent
I/OTPlugin(12227): adding new event - sessionEvents
I/OTPlugin(12227): connect
I/OTPlugin(12227): connect command called
I/OTPlugin(12227): session connected, triggering sessionConnected Event. My Cid is: {OMITTED}
I/OTPlugin(12227): publish
I/OTPlugin(12227): publisher is publishing
I/OTPlugin(12227): view running on UIVIEW!!!
I/OTPlugin(12227): all set up for publisher
I/OTPlugin(12227): updating view in ui runnable["",0,0,264,198,0,"true","true","front"]
I/OTPlugin(12227): updating view in ui runnable com.opentok.android.DefaultVideoRenderer$MyRenderView{422a1600 V.E..... ......I. 0,0-0,0}
I/OTPlugin(12227): publisher stream received
I/OTPlugin(12227): stream received done
```
