### PR TITLE
Fixes dropped calls and multiple streamCreated events

### DIFF
--- a/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
+++ b/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
@@ -143,7 +143,6 @@ public class OpenTokAndroidPlugin extends CordovaPlugin implements
       edit.clear();
       edit.putBoolean("opentok.publisher.accepted", true);
       edit.commit();
-      cordova.getActivity().runOnUiThread( this );
     }
 
     public void setPropertyFromArray( JSONArray args ){
@@ -190,8 +189,6 @@ public class OpenTokAndroidPlugin extends CordovaPlugin implements
         }
         this.mView = mPublisher.getView();
         frame.addView( this.mView );
-      }
-      if(sessionConnected && mPublisher != null){
         mSession.publish(mPublisher);
       }
       super.run();


### PR DESCRIPTION
For some reason, the two lines I deleted in this pull request caused multiple publisher streamCreated events to fire (L146), and sometimes dropped calls (L193). After deleting these, everything went back to working normally.

Here is my logcat output diffed between the plugin prior to your last pull-request, and the plugin after your last-pull request:
https://www.diffchecker.com/ns612xmt (left side is after your last pull-request diff, right side is previous diff)

After I deleted L146, and L193, the diff is as follows (the same):
https://www.diffchecker.com/u76sho1n
