### PR TITLE
add setCameraPosition native function in java

### DIFF
--- a/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
+++ b/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
@@ -398,6 +398,13 @@ public class OpenTokAndroidPlugin extends CordovaPlugin implements
         mSession.setStreamPropertiesListener(this);
         
       // publisher methods
+      }else if( action.equals( "setCameraPosition")){
+        String cameraId = args.getString(0);
+        if (cameraId.equals("front")){
+          myPublisher.mPublisher.setCameraId(1);
+        } else if(cameraId.equals("back")){
+          myPublisher.mPublisher.setCameraId(0);
+        }
       }else if( action.equals( "publishAudio") ){
         String val = args.getString(0);
         boolean publishAudio = true;


### PR DESCRIPTION
#98 Added native java function to respond to cordova's setCameraPositon for android. Clients can now flip camera postion on android as well as ios.
