### PR TITLE
fix bug for sessionDidDisconnect

### DIFF
--- a/src/ios/OpenTokPlugin.m
+++ b/src/ios/OpenTokPlugin.m
@@ -387,8 +387,8 @@
     for ( id key in subscriberDictionary ) {
         OTSubscriber* aStream = [subscriberDictionary objectForKey:key];
         [aStream.view removeFromSuperview];
-        [subscriberDictionary removeObjectForKey:key];
     }
+    [subscriberDictionary removeAllObjects];
     if( _publisher ){
         [_publisher.view removeFromSuperview];
     }
@@ -497,3 +497,4 @@
 
 
 @end
+


### PR DESCRIPTION
Reproduced the bug from #73 and implemented the solution by emptying the array after the for loop. Now the bug does not occur with multiple subscribers.
