### PR TITLE
add publisher video handler for device orientation change

### DIFF
--- a/src/js/OT.coffee
+++ b/src/js/OT.coffee
@@ -52,3 +52,10 @@ window.OT =
     @off( type, handler )
 
 window.TB = OT
+window.addEventListener "orientationchange", (->
+  setTimeout (->
+    OT.updateViews()
+    return
+  ), 1000
+  return
+), false

--- a/www/opentok.js
+++ b/www/opentok.js
@@ -52,6 +52,12 @@ window.OT = {
 
 window.TB = OT;
 
+window.addEventListener("orientationchange", (function() {
+  setTimeout((function() {
+    OT.updateViews();
+  }), 1000);
+}), false);
+
 var TBConnection;
 
 TBConnection = (function() {
@@ -708,13 +714,15 @@ TBSession = (function() {
       reason: "clientDisconnected"
     });
     this.trigger("streamDestroyed", streamEvent);
-    element = streamElements[stream.streamId];
-    if (element) {
-      element.parentNode.removeChild(element);
-      delete streamElements[stream.streamId];
-      TBUpdateObjects();
+    if (stream) {
+      element = streamElements[stream.streamId];
+      if (element) {
+        element.parentNode.removeChild(element);
+        delete streamElements[stream.streamId];
+        TBUpdateObjects();
+      }
+      delete this.streams[stream.streamId];
     }
-    delete this.streams[stream.streamId];
     return this;
   };
 


### PR DESCRIPTION
#116 Now users will always have the publisher video move to the correct place after the web view changes the publisher div's position.
