### PR TITLE
Added more context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Cordova Plugin for OpenTok iOS
 Weave video chat into your web (and now mobile!) application.
 
 ## Using Cordova CLI
-Make sure You have Cordova 3.5.0 Installed. If you haven't, view [Cordova instructions](http://cordova.apache.org/docs/en/3.5.0/guide_cli_index.md.html) Page.  
+Make sure You have Cordova 3.5.0 or greater installed. If you haven't, view [Cordova instructions](http://cordova.apache.org/docs/en/3.5.0/guide_cli_index.md.html) Page.  
 [Bug filed](https://issues.apache.org/jira/browse/CB-6500) against Cordova.  
 
 Clone this repo to get the source code for OpenTok's Cordova plugin


### PR DESCRIPTION
Requirement for only version 3.5.0 was a bit misleading, as it's now on version 4.2.0. I changed it to include 'or greater' to make it clear.