### PR TITLE
It is now possible to specify no dom-id to '.subscribe(stream, domId, props, callback)', which triggers auto-creation of the DOM element.

### DIFF
--- a/src/js/OTSession.coffee
+++ b/src/js/OTSession.coffee
@@ -67,7 +67,8 @@ class TBSession
     @subscriberCallbacks = {}
     if( four? )
       # stream,domId, properties, completionHandler
-      subscriber = new TBSubscriber(one, two, three)
+      domId = two || TBGenerateDomHelper()
+      subscriber = new TBSubscriber(one, domId, three)
       @subscriberCallbacks[one.streamId] = four
       return subscriber
     if( three? )


### PR DESCRIPTION
The 2.6 API of OpenTok specifies this signature for subscribe:
`subscribe(stream, targetElement, properties, completionHandler)`

In OpenTok.js, `targetElement` can be undefined, which causes the DOM element to be created for you. The plugin did not support auto-creation of the DOM element for that particular signature of subscribe. This pull-requests adds that support.