### PR TITLE
Made 'element' and 'id' properties available on Subscriber class.

### DIFF
--- a/src/js/OTSubscriber.coffee
+++ b/src/js/OTSubscriber.coffee
@@ -2,6 +2,7 @@
 #   Properties:
 #     id (string) - dom id of the subscriber
 #     stream (Stream) - stream to which you are subscribing
+#     element (Element) - HTML DOM element containing the Subscriber
 #   Methods: 
 #     getAudioVolume()
 #     getImgData() : String
@@ -35,6 +36,8 @@ class TBSubscriber
 
   constructor: (stream, divName, properties) ->
     element = document.getElementById(divName)
+    @id = divName
+    @element = element
     pdebug "creating subscriber", properties
     @streamId = stream.streamId
     if(properties? && properties.width=="100%" && properties.height == "100%")


### PR DESCRIPTION
This pull-requests makes properties 'element' and 'id' available on the Subscriber class, as specified in the OpenTok.js API:
https://tokbox.com/developer/sdks/js/reference/Subscriber.html

This is especially important when the DOM-element is auto-created by the opentok-plugin, and the UI code needs to grab that element and position it in the DOM tree.
