### PR TITLE
Update android cameraPosition

### DIFF
--- a/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
+++ b/src/android/com/tokbox/cordova/OpenTokAndroidPlugin.java
@@ -401,12 +401,7 @@ public class OpenTokAndroidPlugin extends CordovaPlugin implements
         
       // publisher methods
       }else if( action.equals( "setCameraPosition")){
-        String cameraId = args.getString(0);
-        if (cameraId.equals("front")){
-          myPublisher.mPublisher.setCameraId(1);
-        } else if(cameraId.equals("back")){
-          myPublisher.mPublisher.setCameraId(0);
-        }
+        myPublisher.mPublisher.cycleCamera();
       }else if( action.equals( "publishAudio") ){
         String val = args.getString(0);
         boolean publishAudio = true;


### PR DESCRIPTION
#Proposed Changes
Update serCameraPosition method as setCameraId method deprecated.
Now You should use the new cycleCamera() method to cycle between cameras.